### PR TITLE
min/maxの初期値を現在の価格に変更

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -75,8 +75,8 @@ StockAssistant.launch = function()
 
 			let boughtVal = 0;
 			let stock = 0;
-			let min = 0;
-			let max = 0;
+			let min = Number(Beautify(good.val,2));
+			let max = min;
 
 			// ロードデータあれば使用する
 			if (loadData.goods[idx])


### PR DESCRIPTION
原因はよくわからなかったがmin/maxが0になる時があるらしい。  
とりあえず初期値は現在の価格にする。  